### PR TITLE
Allow trailing spaces after closing braces of a one-line block shortcode

### DIFF
--- a/src/ShortcodeBlockStartParser.php
+++ b/src/ShortcodeBlockStartParser.php
@@ -26,7 +26,7 @@ final class ShortcodeBlockStartParser implements BlockStartParserInterface
     {
         $braceCount = 3;
         foreach (\array_keys($this->shortcodeHandlers) as $code) {
-            $pattern = '/^\{{' . $braceCount . '}' . \preg_quote($code) . '([^ \}]?)(\}{' . $braceCount . '})?/';
+            $pattern = '/^\{{' . $braceCount . '}' . \preg_quote($code) . '([^ \}]?)(\}{' . $braceCount . '})?\s*/';
             $opening = $cursor->match($pattern);
             if ($opening === null) {
                 continue;
@@ -34,8 +34,8 @@ final class ShortcodeBlockStartParser implements BlockStartParserInterface
 
             $shortcode = new Shortcode($code);
             // If the block is closed on the same line as the attributes, strip the trailing braces.
-            $attrsString = \substr($cursor->getLine(), \strlen($code) + $braceCount);
-            $isClosed    = \substr($attrsString, -$braceCount) === '}}}';
+            $attrsString = \substr(\trim($cursor->getLine()), \strlen($code) + $braceCount);
+            $isClosed    = \substr($attrsString, -$braceCount) === \str_repeat('}', $braceCount);
             if ($isClosed) {
                 $attrsString = \substr($attrsString, 0, -$braceCount);
             }

--- a/tests/ShortcodeExtensionTest.php
+++ b/tests/ShortcodeExtensionTest.php
@@ -63,6 +63,15 @@ class ShortcodeExtensionTest extends TestCase
                 ],
                 'output' => "<p>Foo</p>\n[\nbody here]\n<p>baz</p>\n",
             ],
+            'block on one line with trailing space' => [
+                'markdown' => "Foo\n{{{bar|a=b}}} \n",
+                'shortcodes' => [
+                    'bar' => static function (Shortcode $sc) {
+                        return '[' . $sc->getAttr('a') . ']';
+                    },
+                ],
+                'output' => "<p>Foo</p>\n[b]\n",
+            ],
             'block on one line with no attrs' => [
                 'markdown' => "Foo\n\n{{{bar}}}\n\nbaz",
                 'shortcodes' => [


### PR DESCRIPTION
This also fixes the closing-brace check that was not using $braceCount, not that that changes anything because it's always 3.