### PR TITLE
Revert the switch to ShortcodeInline/ShortcodeBlock

### DIFF
--- a/examples/basic.php
+++ b/examples/basic.php
@@ -5,21 +5,20 @@ require dirname( __DIR__ ) . '/vendor/autoload.php';
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\MarkdownConverter;
-use Samwilson\CommonMarkShortcodes\ShortcodeBlock;
+use Samwilson\CommonMarkShortcodes\Shortcode;
 use Samwilson\CommonMarkShortcodes\ShortcodeExtension;
-use Samwilson\CommonMarkShortcodes\ShortcodeInline;
 
 $environment = new Environment([
     'shortcodes' => [
         'shortcodes' => [
-            'inline-shortcode' => function ( ShortcodeInline $shortcode ) {
+            'inline-shortcode' => function ( Shortcode $shortcode ) {
                 return 'Inline shortcode (with ' . count( $shortcode->getAttrs() ) . ' params)';
             },
-            'block-shortcode' => function ( ShortcodeBlock $shortcode ) {
+            'block-shortcode' => function ( Shortcode $shortcode ) {
                 return 'Block-level shortcode (with ' . count( $shortcode->getAttrs() ) . ' params):'
                     .'<pre>' . $shortcode->getBody() . '</pre>';
             },
-            'quote' => function ( ShortcodeBlock $shortcode ) {
+            'quote' => function ( Shortcode $shortcode ) {
                 return '<blockquote>' . $shortcode->getBody() . '<cite>' . $shortcode->getAttr('cite') . '</cite></blockquote>';
             },
         ],

--- a/src/Shortcode.php
+++ b/src/Shortcode.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Samwilson\CommonMarkShortcodes;
 
-trait Shortcode
+class Shortcode
 {
     private string $name;
 
     /** @var string[] */
     private array $attrs = [];
+
+    private string $body = '';
 
     public function __construct(string $name)
     {
@@ -65,18 +67,13 @@ trait Shortcode
         $this->attrs[$key] = $value;
     }
 
-    /**
-     * Not used.
-     */
-    public function getLiteral(): string
+    public function addToBody(string $line): void
     {
-        return '';
+        $this->body .= "\n" . $line;
     }
 
-    /**
-     * Not used.
-     */
-    public function setLiteral(string $literal): void
+    public function getBody(): string
     {
+        return $this->body;
     }
 }

--- a/src/ShortcodeBlock.php
+++ b/src/ShortcodeBlock.php
@@ -9,17 +9,5 @@ use League\CommonMark\Node\RawMarkupContainerInterface;
 
 class ShortcodeBlock extends AbstractBlock implements RawMarkupContainerInterface
 {
-    use Shortcode;
-
-    private string $body = '';
-
-    public function addToBody(string $line): void
-    {
-        $this->body .= "\n" . $line;
-    }
-
-    public function getBody(): string
-    {
-        return $this->body;
-    }
+    use ShortcodeNode;
 }

--- a/src/ShortcodeBlockContinueParser.php
+++ b/src/ShortcodeBlockContinueParser.php
@@ -38,7 +38,7 @@ final class ShortcodeBlockContinueParser extends AbstractBlockContinueParser
             return BlockContinue::finished();
         }
 
-        $this->shortcode->addToBody($cursor->getLine());
+        $this->shortcode->getShortcode()->addToBody($cursor->getLine());
 
         return BlockContinue::at($cursor);
     }

--- a/src/ShortcodeBlockStartParser.php
+++ b/src/ShortcodeBlockStartParser.php
@@ -32,7 +32,7 @@ final class ShortcodeBlockStartParser implements BlockStartParserInterface
                 continue;
             }
 
-            $shortcode = new ShortcodeBlock($code);
+            $shortcode = new Shortcode($code);
             // If the block is closed on the same line as the attributes, strip the trailing braces.
             $attrsString = \substr(\trim($cursor->getLine()), \strlen($code) + $braceCount);
             $isClosed    = \substr($attrsString, -$braceCount) === \str_repeat('}', $braceCount);
@@ -41,7 +41,7 @@ final class ShortcodeBlockStartParser implements BlockStartParserInterface
             }
 
             $shortcode->loadAttrsFromString($attrsString);
-            $startParser = new ShortcodeBlockContinueParser($shortcode, $isClosed);
+            $startParser = new ShortcodeBlockContinueParser(new ShortcodeBlock($shortcode), $isClosed);
 
             return BlockStart::of($startParser)->at($cursor);
         }

--- a/src/ShortcodeInline.php
+++ b/src/ShortcodeInline.php
@@ -9,5 +9,5 @@ use League\CommonMark\Node\RawMarkupContainerInterface;
 
 class ShortcodeInline extends AbstractInline implements RawMarkupContainerInterface
 {
-    use Shortcode;
+    use ShortcodeNode;
 }

--- a/src/ShortcodeInlineParser.php
+++ b/src/ShortcodeInlineParser.php
@@ -33,10 +33,10 @@ final class ShortcodeInlineParser implements InlineParserInterface
 
     public function parse(InlineParserContext $inlineContext): bool
     {
-        $shortcode = new ShortcodeInline($inlineContext->getMatches()[2]);
+        $shortcode = new Shortcode($inlineContext->getMatches()[2]);
         $shortcode->loadAttrsFromString($inlineContext->getMatches()[3]);
         $inlineContext->getCursor()->advanceBy($inlineContext->getFullMatchLength());
-        $inlineContext->getContainer()->appendChild($shortcode);
+        $inlineContext->getContainer()->appendChild(new ShortcodeInline($shortcode));
 
         return true;
     }

--- a/src/ShortcodeNode.php
+++ b/src/ShortcodeNode.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Samwilson\CommonMarkShortcodes;
+
+trait ShortcodeNode
+{
+    private Shortcode $shortcode;
+
+    public function __construct(Shortcode $shortcode)
+    {
+        $this->shortcode = $shortcode;
+    }
+
+    public function getShortcode(): Shortcode
+    {
+        return $this->shortcode;
+    }
+
+    /**
+     * Not used.
+     */
+    public function getLiteral(): string
+    {
+        return '';
+    }
+
+    /**
+     * Not used.
+     */
+    public function setLiteral(string $literal): void
+    {
+    }
+}

--- a/src/ShortcodeRenderer.php
+++ b/src/ShortcodeRenderer.php
@@ -33,10 +33,12 @@ class ShortcodeRenderer implements NodeRendererInterface
             throw new InvalidArgumentException('Incompatible node type');
         }
 
-        if (! isset($this->shortcodeHandlers[$node->getName()])) {
-            return "[Error: shortcode '" . $node->getName() . "' not found.]";
+        $shortcode = $node->getShortcode();
+
+        if (! isset($this->shortcodeHandlers[$shortcode->getName()])) {
+            return "[Error: shortcode '" . $shortcode->getName() . "' not found.]";
         }
 
-        return $this->shortcodeHandlers[$node->getName()]($node);
+        return $this->shortcodeHandlers[$shortcode->getName()]($shortcode);
     }
 }

--- a/tests/ShortcodeExtensionTest.php
+++ b/tests/ShortcodeExtensionTest.php
@@ -8,9 +8,8 @@ use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\MarkdownConverter;
 use PHPUnit\Framework\TestCase;
-use Samwilson\CommonMarkShortcodes\ShortcodeBlock;
+use Samwilson\CommonMarkShortcodes\Shortcode;
 use Samwilson\CommonMarkShortcodes\ShortcodeExtension;
-use Samwilson\CommonMarkShortcodes\ShortcodeInline;
 
 class ShortcodeExtensionTest extends TestCase
 {
@@ -49,7 +48,7 @@ class ShortcodeExtensionTest extends TestCase
             'simple-inline-params' => [
                 'markdown' => 'Foo {bar |a |b=c|d=e f} baz',
                 'shortcodes' => [
-                    'bar' => static function (ShortcodeInline $sc) {
+                    'bar' => static function (Shortcode $sc) {
                         return $sc->getAttr('d') . $sc->getAttr('b');
                     },
                 ],
@@ -58,7 +57,7 @@ class ShortcodeExtensionTest extends TestCase
             'simple-block' => [
                 'markdown' => "Foo\n{{{bar | attr=foo\nbody here\n}}}\nbaz",
                 'shortcodes' => [
-                    'bar' => static function (ShortcodeBlock $sc) {
+                    'bar' => static function (Shortcode $sc) {
                         return '[' . $sc->getBody() . ']';
                     },
                 ],
@@ -67,7 +66,7 @@ class ShortcodeExtensionTest extends TestCase
             'block on one line with trailing space' => [
                 'markdown' => "Foo\n{{{bar|a=b}}} \n",
                 'shortcodes' => [
-                    'bar' => static function (ShortcodeBlock $sc) {
+                    'bar' => static function (Shortcode $sc) {
                         return '[' . $sc->getAttr('a') . ']';
                     },
                 ],
@@ -85,7 +84,7 @@ class ShortcodeExtensionTest extends TestCase
             'block on one line with attrs' => [
                 'markdown' => "Foo\n\n{{{bar|lorem=ip sum}}}\n\nbaz",
                 'shortcodes' => [
-                    'bar' => static function (ShortcodeBlock $sc) {
+                    'bar' => static function (Shortcode $sc) {
                         return $sc->getAttr('lorem');
                     },
                 ],

--- a/tests/ShortcodeTest.php
+++ b/tests/ShortcodeTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Samwilson\CommonMarkShortcodes\Test;
 
 use PHPUnit\Framework\TestCase;
-use Samwilson\CommonMarkShortcodes\ShortcodeBlock;
+use Samwilson\CommonMarkShortcodes\Shortcode;
 
 class ShortcodeTest extends TestCase
 {
@@ -16,7 +16,7 @@ class ShortcodeTest extends TestCase
      */
     public function testLoadAttrsFromString(string $name, string $string, array $expected): void
     {
-        $shortcode = new ShortcodeBlock($name);
+        $shortcode = new Shortcode($name);
         $shortcode->loadAttrsFromString($string);
         $this->assertSame($expected, $shortcode->getAttrs());
     }


### PR DESCRIPTION
It's much easier if the callbacks don't have to know what sort of node they're recieving, so this restores the previous behaviour of just providing a Shortcode object to both block and inline nodes.