### PR TITLE
Fix bug with shortcodes having matching prefixes

### DIFF
--- a/src/ShortcodeInlineParser.php
+++ b/src/ShortcodeInlineParser.php
@@ -23,9 +23,15 @@ final class ShortcodeInlineParser implements InlineParserInterface
 
     public function getMatchDefinition(): InlineParserMatch
     {
+        // Sort shortcodes by length, so they match from longest to shortest in the regex.
+        $sortedShortcodeNames = \array_keys($this->shortcodes);
+        \usort($sortedShortcodeNames, static function ($a, $b) {
+            return \strlen($b) - \strlen($a);
+        });
+
         return InlineParserMatch::join(
             InlineParserMatch::string('{'),
-            InlineParserMatch::oneOf(...\array_keys($this->shortcodes)),
+            InlineParserMatch::oneOf(...$sortedShortcodeNames),
             InlineParserMatch::regex('.*?'),
             InlineParserMatch::string('}')
         );

--- a/tests/ShortcodeExtensionTest.php
+++ b/tests/ShortcodeExtensionTest.php
@@ -34,12 +34,12 @@ class ShortcodeExtensionTest extends TestCase
     {
         return [
             'simple-inline' => [
-                'markdown' => 'Foo {bar} baz {bif}',
+                'markdown' => 'Foo {bar} baz {barbif}',
                 'shortcodes' => [
                     'bar' => static function () {
                         return 'BAR';
                     },
-                    'bif' => static function () {
+                    'barbif' => static function () {
                         return 'BIF';
                     },
                 ],


### PR DESCRIPTION
Solve by first sorting from longest to shortest, so the regex alternation matches the most specific first.