### PR TITLE
Backslash-escaping for inline shortcode closing braces

### DIFF
--- a/src/Shortcode.php
+++ b/src/Shortcode.php
@@ -45,7 +45,9 @@ class Shortcode
                 $unnamedIndex++;
             }
 
-            $this->setAttr(\trim((string) $name), \str_replace('\\|', '|', \trim($value)));
+            $unescapedClosingBrace = \str_replace('\\}', '}', \trim($value));
+            $unescapedPipes        = \str_replace('\\|', '|', $unescapedClosingBrace);
+            $this->setAttr(\trim((string) $name), $unescapedPipes);
         }
     }
 

--- a/src/ShortcodeInlineParser.php
+++ b/src/ShortcodeInlineParser.php
@@ -32,7 +32,8 @@ final class ShortcodeInlineParser implements InlineParserInterface
         return InlineParserMatch::join(
             InlineParserMatch::string('{'),
             InlineParserMatch::oneOf(...$sortedShortcodeNames),
-            InlineParserMatch::regex('.*?'),
+            // Match either two backslashes, a backslash-brace, or anything that's not a brace.
+            InlineParserMatch::regex('(?:\\\\\\\\|\\\\}|[^}])*'),
             InlineParserMatch::string('}')
         );
     }

--- a/tests/ShortcodeExtensionTest.php
+++ b/tests/ShortcodeExtensionTest.php
@@ -54,6 +54,15 @@ class ShortcodeExtensionTest extends TestCase
                 ],
                 'output' => "<p>Foo e fc baz</p>\n",
             ],
+            'inline-escape-chars' => [
+                'markdown' => 'outer {one| inner1 {two\|inner2\}}',
+                'shortcodes' => [
+                    'one' => static function (Shortcode $sc) {
+                        return '[ONE ' . $sc->getAttr('1') . ']';
+                    },
+                ],
+                'output' => "<p>outer [ONE inner1 {two|inner2}]</p>\n",
+            ],
             'simple-block' => [
                 'markdown' => "Foo\n{{{bar | attr=foo\nbody here\n}}}\nbaz",
                 'shortcodes' => [


### PR DESCRIPTION
Make it possible to escape closing braces in inline shortcodes, by prefixing them with a backslash. The regex also makes it possible to escape those backslashes in case it's necessary to have an actual `\}` in a attribute value.

The pipe character already supported being escaped.